### PR TITLE
Fixed GFF file writing errors

### DIFF
--- a/KIOTest/FieldTypeTests/ByteTests.cs
+++ b/KIOTest/FieldTypeTests/ByteTests.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using KotOR_IO;
+
+namespace FieldTypeTests
+{
+    [TestClass]
+    public class ByteTests
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/KIOTest/FileFormatTests/BIFTests.cs
+++ b/KIOTest/FileFormatTests/BIFTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using KotOR_IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FileFormatTests
+{
+    [TestClass]
+    public class BIFTests
+    {
+        /// <summary>
+        /// Verify that BIF.ToRawData() returns an array of data with equivalent length to the
+        /// data used to construct the BIF object.
+        /// </summary>
+        [TestMethod]
+        public void ToRawData_SimpleRead_SizeUnchanged()
+        {
+            // Arrange
+            var fileToRead = @"C:\Program Files (x86)\Steam\steamapps\common\swkotor\data\templates.bif";
+            var oldFileInfo = new FileInfo(fileToRead);
+            long oldSize = oldFileInfo.Length;
+            BIF bif = new BIF(fileToRead);
+
+            // Act
+            var rawData = bif.ToRawData();
+
+            // Assert
+            long newSize = rawData.Length;
+            Assert.AreEqual(oldSize, newSize, "Size of raw data has changed.");
+        }
+
+        /// <summary>
+        /// Verify that BIF.WriteToFile() creates a data file of equivalent size to the file
+        /// used to construct the BIF object.
+        /// </summary>
+        [TestMethod]
+        public void WriteToFile_ValidPath_SizeUnchanged()
+        {
+            // Arrange
+            var pathToRead = @"C:\Program Files (x86)\Steam\steamapps\common\swkotor\data\templates.bif";
+            var pathToWrite = Environment.CurrentDirectory + "templates_copy.bif";
+            var oldFileInfo = new FileInfo(pathToRead);
+            long oldSize = oldFileInfo.Length;
+            BIF bif = new BIF(pathToRead);
+
+            // Act
+            bif.WriteToFile(pathToWrite);
+            var newFileInfo = new FileInfo(pathToWrite);
+
+            // Assert
+            long newSize = newFileInfo.Length;
+            Assert.AreEqual(oldSize, newSize, "Size of raw data has changed.");
+
+            // Cleanup
+            File.Delete(pathToWrite);
+        }
+    }
+}

--- a/KIOTest/FileFormatTests/GFFTests.cs
+++ b/KIOTest/FileFormatTests/GFFTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Linq;
+using KotOR_IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FileFormatTests
+{
+    [TestClass]
+    public class GFFTests
+    {
+        /// <summary>
+        /// Verify that GFF.ToRawData() returns an array of data with equivalent length to the
+        /// data used to construct the GFF object.
+        /// </summary>
+        [TestMethod]
+        public void ToRawData_SimpleRead_SizeUnchanged()
+        {
+            // Arrange
+            var fileToRead = @"C:\Program Files (x86)\Steam\steamapps\common\swkotor\data\templates.bif";
+            BIF templates = new BIF(fileToRead);
+            var vre = templates.VariableResourceTable.First(vre => vre.ResourceType == ResourceType.UTC);
+            int oldSize = vre.EntryData.Length;
+            GFF utc = new GFF(vre.EntryData);
+
+            // Act
+            var rawData = utc.ToRawData();
+
+            // Assert
+            int newSize = rawData.Length;
+            Assert.AreEqual(oldSize, newSize, "Size of raw data has changed.");
+        }
+
+        /// <summary>
+        /// Verify that GFF.WriteToFile() creates a data file of equivalent size to the file
+        /// used to construct the GFF object.
+        /// </summary>
+        [TestMethod]
+        public void WriteToFile_ValidPath_SizeUnchanged()
+        {
+            // Arrange
+            string pathToRead = @"C:\Dev\KIO Test\test1.git";
+            string pathToWrite = @"C:\Dev\KIO Test\test1_copy.git";
+            FileInfo oldFileInfo = new FileInfo(pathToRead);
+            GFF gff = new GFF(pathToRead);
+
+            // Act
+            gff.WriteToFile(pathToWrite);
+            FileInfo newFileInfo = new FileInfo(pathToWrite);
+
+            // Assert
+            var oldFileSize = oldFileInfo.Length;
+            var newFileSize = newFileInfo.Length;
+            Assert.AreEqual(oldFileSize, newFileSize, "File size has changed.");
+
+            // Cleanup
+            File.Delete(pathToWrite);
+        }
+    }
+}

--- a/KIOTest/KIOTest.csproj
+++ b/KIOTest/KIOTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KotOR_IO\KotOR_IO.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/KotOR_IO.sln
+++ b/KotOR_IO.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31729.503
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KotOR_IO", "KotOR_IO\KotOR_IO.csproj", "{DDB8235B-7C51-4810-83EC-837BF040DFC2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test8", "test8\test8.csproj", "{ABF89826-3445-433D-8CE9-F87DA18DA009}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KIOTest", "KIOTest\KIOTest.csproj", "{AC363A4C-C268-4612-B2D6-609CEBFA9C87}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +23,15 @@ Global
 		{ABF89826-3445-433D-8CE9-F87DA18DA009}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABF89826-3445-433D-8CE9-F87DA18DA009}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ABF89826-3445-433D-8CE9-F87DA18DA009}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AC363A4C-C268-4612-B2D6-609CEBFA9C87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AC363A4C-C268-4612-B2D6-609CEBFA9C87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AC363A4C-C268-4612-B2D6-609CEBFA9C87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AC363A4C-C268-4612-B2D6-609CEBFA9C87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C99B0B8E-BCBF-4E28-BC04-66489EFD9B62}
 	EndGlobalSection
 EndGlobal

--- a/KotOR_IO/File Formats/GFF FieldTypes/0_BYTE.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/0_BYTE.cs
@@ -98,10 +98,10 @@ namespace KotOR_IO
             /// Generate a hash code for this BYTE.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write BYTE information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/0_BYTE.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/0_BYTE.cs
@@ -7,17 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A BYTE is a 1-byte signed numeric value.
+        /// </summary>
         public class BYTE : FIELD
         {
-            public byte Value;
+            /// <summary>
+            /// Byte value
+            /// </summary>
+            public byte Value { get; set; }
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public BYTE() : base(GffFieldType.BYTE) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public BYTE(string label, byte value)
                 : base(GffFieldType.BYTE, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal BYTE(BinaryReader br, int offset)
                 : base(GffFieldType.BYTE)
             {
@@ -36,8 +56,20 @@ namespace KotOR_IO
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
             }
 
-
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, (int)Value, this.GetHashCode());
                 Field_Array.Add(T);
@@ -48,23 +80,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two BYTE objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as BYTE).Value && Label == (obj as BYTE).Label;
-                }
+
+                return Value == (right as BYTE).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this BYTE.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write BYTE information to string.
+            /// </summary>
+            /// <returns>[BYTE] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/1_CHAR.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/1_CHAR.cs
@@ -7,17 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A CHAR is a 1-byte character value.
+        /// </summary>
         public class CHAR : FIELD
         {
-            public char Value;
+            /// <summary>
+            /// Character value
+            /// </summary>
+            public char Value { get; set; }
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public CHAR() : base(GffFieldType.CHAR) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public CHAR(string label, char value)
                 : base(GffFieldType.CHAR, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal CHAR(BinaryReader br, int offset)
                 : base(GffFieldType.CHAR)
             {
@@ -34,10 +54,22 @@ namespace KotOR_IO
                 //Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, (int)Value, this.GetHashCode());
                 Field_Array.Add(T);
@@ -48,23 +80,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two CHAR objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as CHAR).Value && Label == (obj as CHAR).Label;
-                }
+
+                return Value == (right as CHAR).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this BYTE.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write CHAR information to string.
+            /// </summary>
+            /// <returns>[CHAR] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, \'{Value}\'";

--- a/KotOR_IO/File Formats/GFF FieldTypes/1_CHAR.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/1_CHAR.cs
@@ -98,10 +98,10 @@ namespace KotOR_IO
             /// Generate a hash code for this BYTE.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write CHAR information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/2_WORD.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/2_WORD.cs
@@ -7,17 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A WORD is a 2-byte unsigned numeric value.
+        /// </summary>
         public class WORD : FIELD
         {
-            public ushort Value;
+            /// <summary>
+            /// Word value
+            /// </summary>
+            public ushort Value { get; set; }
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public WORD() : base(GffFieldType.WORD) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public WORD(string label, ushort value)
                 : base(GffFieldType.WORD, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal WORD(BinaryReader br, int offset)
                 : base(GffFieldType.WORD)
             {
@@ -34,10 +54,22 @@ namespace KotOR_IO
                 //Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, (int)Value, this.GetHashCode());
                 Field_Array.Add(T);
@@ -48,23 +80,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two WORD objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as WORD).Value && Label == (obj as WORD).Label;
-                }
+
+                return Value == (right as WORD).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this WORD.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write WORD information to string.
+            /// </summary>
+            /// <returns>[WORD] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/2_WORD.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/2_WORD.cs
@@ -98,10 +98,10 @@ namespace KotOR_IO
             /// Generate a hash code for this WORD.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write WORD information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/3_SHORT.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/3_SHORT.cs
@@ -7,17 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A SHORT is a 2-byte signed numeric value.
+        /// </summary>
         public class SHORT : FIELD
         {
-            public short Value;
+            /// <summary>
+            /// SHORT value
+            /// </summary>
+            public short Value { get; set; }
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public SHORT() : base(GffFieldType.SHORT) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public SHORT(string label, short value)
                 : base(GffFieldType.SHORT, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal SHORT(BinaryReader br, int offset)
                 : base(GffFieldType.SHORT)
             {
@@ -37,7 +57,20 @@ namespace KotOR_IO
 
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, (int)Value, this.GetHashCode());
                 Field_Array.Add(T);
@@ -48,23 +81,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two SHORT objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as SHORT).Value && Label == (obj as SHORT).Label;
-                }
+
+                return Value == (right as SHORT).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this SHORT.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write SHORT information to string.
+            /// </summary>
+            /// <returns>[SHORT] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/3_SHORT.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/3_SHORT.cs
@@ -99,10 +99,10 @@ namespace KotOR_IO
             /// Generate a hash code for this SHORT.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write SHORT information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/4_DWORD.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/4_DWORD.cs
@@ -7,17 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A DWORD is a 4-byte unsigned numeric value.
+        /// </summary>
         public class DWORD : FIELD
         {
-            public uint Value;
+            /// <summary>
+            /// 4-byte unsigned value
+            /// </summary>
+            public uint Value { get; set; }
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public DWORD() : base(GffFieldType.DWORD) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public DWORD(string label, uint value)
                 : base(GffFieldType.DWORD, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal DWORD(BinaryReader br, int offset)
                 : base(GffFieldType.DWORD)
             {
@@ -34,10 +54,22 @@ namespace KotOR_IO
                 //Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, BitConverter.ToInt32((BitConverter.GetBytes(Value)), 0), this.GetHashCode());
                 Field_Array.Add(T);
@@ -48,23 +80,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two DWORD objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as DWORD).Value && Label == (obj as DWORD).Label;
-                }
+
+                return Value == (right as DWORD).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this DWORD.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write DWORD information to string.
+            /// </summary>
+            /// <returns>[DWORD] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/4_DWORD.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/4_DWORD.cs
@@ -98,10 +98,10 @@ namespace KotOR_IO
             /// Generate a hash code for this DWORD.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write DWORD information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/5_INT.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/5_INT.cs
@@ -98,10 +98,10 @@ namespace KotOR_IO
             /// Generate a hash code for this INT.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write INT information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/5_INT.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/5_INT.cs
@@ -7,17 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// An INT is a 4-byte signed numeric value.
+        /// </summary>
         public class INT : FIELD
         {
-            public int Value;
+            /// <summary>
+            /// 4-byte signed value
+            /// </summary>
+            public int Value { get; set; }
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public INT() : base(GffFieldType.INT) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public INT(string label, int value)
                 : base(GffFieldType.INT, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal INT(BinaryReader br, int offset)
                 : base(GffFieldType.INT)
             {
@@ -34,10 +54,22 @@ namespace KotOR_IO
                 //Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, (int)Value, this.GetHashCode());
                 Field_Array.Add(T);
@@ -48,23 +80,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two INT objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as INT).Value && Label == (obj as INT).Label;
-                }
+
+                return Value == (right as INT).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this INT.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write INT information to string.
+            /// </summary>
+            /// <returns>[INT] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/6_DWORD64.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/6_DWORD64.cs
@@ -105,10 +105,10 @@ namespace KotOR_IO
             /// Generate a hash code for this DWORD64.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write DWORD64 information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/6_DWORD64.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/6_DWORD64.cs
@@ -7,16 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A DWORD64 is an 8-byte unsigned numeric value.
+        /// </summary>
         public class DWORD64 : FIELD
         {
-            public ulong Value;
+            /// <summary>
+            /// 8-byte unsigned value
+            /// </summary>
+            public ulong Value { get; set; }
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public DWORD64() : base(GffFieldType.DWORD64) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public DWORD64(string label, ulong value)
                 : base(GffFieldType.DWORD64, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal DWORD64(BinaryReader br, int offset)
                 : base(GffFieldType.DWORD64)
             {
@@ -39,11 +60,22 @@ namespace KotOR_IO
                 //Comlex Value Logic
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 Value = br.ReadUInt64();
-
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(Value));
@@ -55,23 +87,33 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two DWORD64 objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as DWORD64).Value && Label == (obj as DWORD64).Label;
-                }
+
+                return Value == (right as DWORD64).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this DWORD64.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write DWORD64 information to string.
+            /// </summary>
+            /// <returns>[DWORD64] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/7_INT64.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/7_INT64.cs
@@ -7,16 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// An INT64 is an 8-byte signed numeric value.
+        /// </summary>
         public class INT64 : FIELD
         {
-            public long Value;
+            /// <summary>
+            /// 8-byte signed value
+            /// </summary>
+            public long Value { get; set; }
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public INT64() : base(GffFieldType.INT64) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public INT64(string label, long value)
                 : base(GffFieldType.INT64, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal INT64(BinaryReader br, int offset)
                 : base(GffFieldType.INT64)
             {
@@ -39,11 +60,22 @@ namespace KotOR_IO
                 //Comlex Value Logic
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 Value = br.ReadInt64();
-
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(Value));
@@ -55,23 +87,34 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two INT64 objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as INT64).Value && Label == (obj as INT64).Label;
-                }
+
+                // Check value
+                return Value == (right as INT64).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this INT64.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write INT64 information to string.
+            /// </summary>
+            /// <returns>[INT64] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/7_INT64.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/7_INT64.cs
@@ -106,10 +106,10 @@ namespace KotOR_IO
             /// Generate a hash code for this INT64.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write INT64 information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/8_FLOAT.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/8_FLOAT.cs
@@ -7,16 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A FLOAT is a 4-byte single-precision floating point value.
+        /// </summary>
         public class FLOAT : FIELD
         {
-            public float Value;
+            /// <summary>
+            /// 4-byte single-precision floating point value
+            /// </summary>
+            public float Value { get; set; }
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public FLOAT() : base(GffFieldType.FLOAT) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public FLOAT(string label, float value)
                 : base(GffFieldType.FLOAT, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal FLOAT(BinaryReader br, int offset)
                 : base(GffFieldType.FLOAT)
             {
@@ -33,10 +54,22 @@ namespace KotOR_IO
                 //Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, BitConverter.ToInt32((BitConverter.GetBytes(Value)), 0), this.GetHashCode());
                 Field_Array.Add(T);
@@ -47,23 +80,34 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two FLOAT objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as FLOAT).Value && Label == (obj as FLOAT).Label;
-                }
+
+                // Check value
+                return Value == (right as FLOAT).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this FLOAT.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write FLOAT information to string.
+            /// </summary>
+            /// <returns>[FLOAT] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/8_FLOAT.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/8_FLOAT.cs
@@ -99,10 +99,10 @@ namespace KotOR_IO
             /// Generate a hash code for this FLOAT.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write FLOAT information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/9_DOUBLE.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/9_DOUBLE.cs
@@ -7,16 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A DOUBLE is an 8-byte double-precision floating point value.
+        /// </summary>
         public class DOUBLE : FIELD
         {
-            public double Value;
+            /// <summary>
+            /// 8-byte double-precision floating point value
+            /// </summary>
+            public double Value { get; set; }
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public DOUBLE() : base(GffFieldType.DOUBLE) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="value"></param>
             public DOUBLE(string label, double value)
                 : base(GffFieldType.DOUBLE, label)
             {
                 Value = value;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal DOUBLE(BinaryReader br, int offset)
                 : base(GffFieldType.DOUBLE)
             {
@@ -39,10 +60,22 @@ namespace KotOR_IO
                 //Comlex Value Logic
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 Value = br.ReadDouble();
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(Value));
@@ -54,23 +87,34 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two DOUBLE objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value == (obj as DOUBLE).Value && Label == (obj as DOUBLE).Label;
-                }
+
+                // Check value
+                return Value == (right as DOUBLE).Value;
             }
 
+            /// <summary>
+            /// Generate a hash code for this DOUBLE.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write DOUBLE information to string.
+            /// </summary>
+            /// <returns>[DOUBLE] "Label", Value</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, {Value}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/9_DOUBLE.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/9_DOUBLE.cs
@@ -106,10 +106,10 @@ namespace KotOR_IO
             /// Generate a hash code for this DOUBLE.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write DOUBLE information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/A_CExoString.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/A_CExoString.cs
@@ -108,10 +108,10 @@ namespace KotOR_IO
             /// Generate a hash code for this CExoString.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, CEString, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, CEString, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write CExoString information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/A_CExoString.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/A_CExoString.cs
@@ -7,16 +7,37 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A CExoString is a string with length less than uint.MaxValue.
+        /// </summary>
         public class CExoString : FIELD
         {
-            public string CEString;
+            /// <summary>
+            /// String value
+            /// </summary>
+            public string CEString { get; set; }
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public CExoString() : base(GffFieldType.CExoString) { }
-            public CExoString(string label, string cEString)
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="ceStr"></param>
+            public CExoString(string label, string ceStr)
                 : base(GffFieldType.CExoString, label)
             {
-                CEString = cEString;
+                CEString = ceStr;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal CExoString(BinaryReader br, int offset)
                 : base(GffFieldType.CExoString)
             {
@@ -40,10 +61,22 @@ namespace KotOR_IO
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 int Size = br.ReadInt32();
                 CEString = new string(br.ReadChars(Size));
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(CEString.Length));
@@ -56,23 +89,34 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two CExoString objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return CEString == (obj as CExoString).CEString && Label == (obj as CExoString).Label;
-                }
+
+                // Check value
+                return CEString == (right as CExoString).CEString;
             }
 
+            /// <summary>
+            /// Generate a hash code for this CExoString.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, CEString, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write CExoString information to string.
+            /// </summary>
+            /// <returns>[CExoString] "Label", "String"</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, \"{CEString}\"";

--- a/KotOR_IO/File Formats/GFF FieldTypes/B_ResRef.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/B_ResRef.cs
@@ -7,11 +7,32 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A ResRef is a string used to store the name of a file used by the game or toolset.
+        /// Up to 16 characters, not null-terminated, non-case-sensitive, and stored in all lower-case.
+        /// </summary>
         public class ResRef : FIELD
         {
-            public string Reference;
+            /// <summary>
+            /// String up to 16 characters long.
+            /// </summary>
+            public string Reference
+            {
+                get => _reference;
+                set => _reference = value.ToLower();
+            }
+            private string _reference;
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public ResRef() : base(GffFieldType.ResRef) { }
+
+            /// <summary>
+            /// Construct with label and value.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="reference"></param>
             public ResRef(string label, string reference)
                 : base(GffFieldType.ResRef, label)
             {
@@ -19,6 +40,12 @@ namespace KotOR_IO
                     throw new Exception($"Reference \"{reference}\" with a length of {reference.Length} is longer than {MAX_LABEL_LENGTH} characters, and cannot be used for GFF type ResRef");
                 Reference = reference;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal ResRef(BinaryReader br, int offset)
                 : base(GffFieldType.ResRef)
             {
@@ -42,10 +69,22 @@ namespace KotOR_IO
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 byte Size = br.ReadByte();
                 Reference = new string(br.ReadChars(Size));
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.Add((byte)Reference.Length);
@@ -58,23 +97,35 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two ResRef objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Reference == (obj as ResRef).Reference && Label == (obj as ResRef).Label;
-                }
+
+                // Check value
+                //return Reference.Equals((right as ResRef).Reference, StringComparison.InvariantCultureIgnoreCase);
+                return Reference == (right as ResRef).Reference;
             }
 
+            /// <summary>
+            /// Generate a hash code for this ResRef.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Reference, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write ResRef information to string.
+            /// </summary>
+            /// <returns>[ResRef] "Label", "String"</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, \"{Reference}\"";

--- a/KotOR_IO/File Formats/GFF FieldTypes/B_ResRef.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/B_ResRef.cs
@@ -117,10 +117,10 @@ namespace KotOR_IO
             /// Generate a hash code for this ResRef.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Reference, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Reference, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write ResRef information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/C_CExoLocString.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/C_CExoLocString.cs
@@ -163,21 +163,21 @@ namespace KotOR_IO
             /// Generate a hash code for this CExoLocString.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                int partial_hash = 1;
-                int[] IDArray = Strings.Select(x => x.StringID).ToArray();
-                foreach (int i in IDArray)
-                {
-                    partial_hash *= i.GetHashCode();
-                }
-                string[] StringArray = Strings.Select(x => x.SString).ToArray();
-                foreach (string s in StringArray)
-                {
-                    partial_hash *= s.GetHashCode();
-                }
-                return new { Type, StringRef, partial_hash, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    int partial_hash = 1;
+            //    int[] IDArray = Strings.Select(x => x.StringID).ToArray();
+            //    foreach (int i in IDArray)
+            //    {
+            //        partial_hash *= i.GetHashCode();
+            //    }
+            //    string[] StringArray = Strings.Select(x => x.SString).ToArray();
+            //    foreach (string s in StringArray)
+            //    {
+            //        partial_hash *= s.GetHashCode();
+            //    }
+            //    return new { Type, StringRef, partial_hash, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write CExoLocString information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/D_VOID.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/D_VOID.cs
@@ -113,16 +113,16 @@ namespace KotOR_IO
             /// Generate a hash code for this VOID.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                int partial_hash = 1;
-                byte[] dataArray = Data.ToArray();
-                foreach (byte b in dataArray)
-                {
-                    partial_hash *= b.GetHashCode();
-                }
-                return new { Type, partial_hash, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    int partial_hash = 1;
+            //    byte[] dataArray = Data.ToArray();
+            //    foreach (byte b in dataArray)
+            //    {
+            //        partial_hash *= b.GetHashCode();
+            //    }
+            //    return new { Type, partial_hash, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write VOID information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/D_VOID.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/D_VOID.cs
@@ -7,47 +7,81 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// VOID data is an arbitrary sequence of bytes to be interpreted by the application
+        /// in a programmer-defined fashion.
+        /// </summary>
         public class VOID : FIELD
         {
-            public List<byte> Data = new List<byte>();
+            /// <summary>
+            /// Byte data.
+            /// </summary>
+            public List<byte> Data { get; set; } = new List<byte>();
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public VOID() : base(GffFieldType.VOID) { }
+
+            /// <summary>
+            /// Construct with label and data.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="data"></param>
             public VOID(string label, List<byte> data)
                 : base(GffFieldType.VOID, label)
             {
                 Label = label;
                 Data = data;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal VOID(BinaryReader br, int offset)
                 : base(GffFieldType.VOID)
             {
-                //Header Info
+                // Header Info
                 br.BaseStream.Seek(24, 0);
                 int LabelOffset = br.ReadInt32();
                 int LabelCount = br.ReadInt32();
                 int FieldDataOffset = br.ReadInt32();
 
-                //Basic Field Data
+                // Basic Field Data
                 br.BaseStream.Seek(offset, 0);
                 Type = (GffFieldType)br.ReadInt32();
                 int LabelIndex = br.ReadInt32();
                 int DataOrDataOffset = br.ReadInt32();
 
-                //Label Logic
+                // Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
 
-                //Comlex Value Logic
+                // Complex Value Logic
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 int Size = br.ReadInt32();
                 for (int i = 0; i < Size; i++)
                 {
                     Data.Add(br.ReadByte());
                 }
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(Data.Count));
@@ -60,18 +94,25 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two VOID objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Data == (obj as VOID).Data && Label == (obj as VOID).Label;
-                }
+
+                // Check data
+                return Data == (right as VOID).Data;
             }
 
+            /// <summary>
+            /// Generate a hash code for this VOID.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 int partial_hash = 1;
@@ -83,6 +124,10 @@ namespace KotOR_IO
                 return new { Type, partial_hash, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write VOID information to string.
+            /// </summary>
+            /// <returns>[VOID] "Label", Size of Data = _</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, Size of Data = {Data?.Count ?? 0}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/E_Struct.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/E_Struct.cs
@@ -7,26 +7,44 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A STRUCT is a collection of FIELD objects.
+        /// </summary>
         public class STRUCT : FIELD
         {
-            //Declarations
-            public int Struct_Type;
+            /// <summary>
+            /// Type of this STRUCT.
+            /// </summary>
+            public int Struct_Type { get; set; }
 
-            public List<FIELD> Fields = new List<FIELD>();
+            /// <summary>
+            /// Fields this struct contains.
+            /// </summary>
+            public List<FIELD> Fields { get; set; } = new List<FIELD>();
 
-            //Construction
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public STRUCT() : base(GffFieldType.Struct) { }
+
+            /// <summary>
+            /// Construct using a custom list of fields.
+            /// </summary>
             public STRUCT(string label, int structType, List<FIELD> fields)
                 : base(GffFieldType.Struct, label)
             {
                 Struct_Type = structType;
                 Fields = fields;
             }
+
+            /// <summary>
+            /// Construct by reading from a binary reader.
+            /// </summary>
             internal STRUCT(BinaryReader br, int index, int LabelIndex = -1)
                 : base(GffFieldType.Struct)
             {
-                //Header Info
-                br.BaseStream.Seek(8, 0);
+                // Header info
+                br.BaseStream.Seek(SIZEOF_FILEINFO, SeekOrigin.Begin);
                 int StructOffset = br.ReadInt32();
                 int StuctCount = br.ReadInt32();
                 int FieldOffset = br.ReadInt32();
@@ -36,8 +54,11 @@ namespace KotOR_IO
                 int FieldDataOffset = br.ReadInt32();
                 int FieldDataCount = br.ReadInt32();
                 int FieldIndicesOffset = br.ReadInt32();
-
-                //label logic
+                // FieldIndicesCount
+                // ListIndicesOffset
+                // ListIndicesCount
+                
+                // Label logic
                 if (LabelIndex < 0 || LabelIndex > LabelCount)
                 {
                     Label = "";
@@ -48,13 +69,13 @@ namespace KotOR_IO
                     Label = new string(br.ReadChars(16)).TrimEnd('\0');
                 }
 
-                //Struct Info
+                // Struct info
                 br.BaseStream.Seek(StructOffset + index * 12, 0);
                 Struct_Type = br.ReadInt32();
                 int DataOrDataOffset = br.ReadInt32();
                 int S_FieldCount = br.ReadInt32();
 
-                //If there is only one field, it pulls it from the field area
+                // If there is only one field, it pulls it from the field area
                 if (S_FieldCount == 1)
                 {
                     br.BaseStream.Seek(FieldOffset + DataOrDataOffset * 12, 0);
@@ -62,7 +83,7 @@ namespace KotOR_IO
                     FIELD data = CreateNewField(br, index, FieldOffset, DataOrDataOffset, fieldType);
                     Fields.Add(data);
                 }
-                //If there is more than one field, a set of Indices are read off, and then those fields are read in
+                // If there is more than one field, a set of Indices are read off, and then those fields are read in
                 else if (S_FieldCount > 1)
                 {
                     for (int i = 0; i < S_FieldCount; i++)
@@ -86,7 +107,21 @@ namespace KotOR_IO
                 }
             }
 
-            private static FIELD CreateNewField(BinaryReader br, int index, int fieldOffset, int dataOrDataOffset, GffFieldType fieldType)
+            /// <summary>
+            /// Construct a new field
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="index"></param>
+            /// <param name="fieldOffset"></param>
+            /// <param name="dataOrDataOffset"></param>
+            /// <param name="fieldType"></param>
+            /// <returns></returns>
+            private static FIELD CreateNewField(
+                BinaryReader br,
+                int index,
+                int fieldOffset,
+                int dataOrDataOffset,
+                GffFieldType fieldType)
             {
                 FIELD data;
                 switch (fieldType)
@@ -156,10 +191,20 @@ namespace KotOR_IO
                 return data;
             }
 
-
-
-            //Other
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Struct_Indexer, this.GetHashCode());
                 Struct_Indexer++;
@@ -176,44 +221,41 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two STRUCT objects.
+            /// </summary>
+            /// <returns>True if the structs have the same Struct_Type, Label, and Fields.</returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else
+
+                var other = right as STRUCT;
+
+                // Check field count
+                if (Fields.Count() != other.Fields.Count())
+                    return false;
+
+                // Check Struct_Type
+                if (Struct_Type != other.Struct_Type)
+                    return false;
+
+                // Check each FIELD
+                foreach (FIELD f in Fields)
                 {
-                    if (Fields.Count() != (obj as STRUCT).Fields.Count())
-                    {
+                    if (!other.Fields.Contains(f))
                         return false;
-                    }
-                    else if (Struct_Type != (obj as STRUCT).Struct_Type)
-                    {
-                        return false;
-                    }
-                    else if (Label != (obj as STRUCT).Label)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        foreach (FIELD f in Fields)
-                        {
-                            if ((obj as STRUCT).Fields.Contains(f))
-                            {
-                                continue;
-                            }
-                            else
-                            {
-                                return false;
-                            }
-                        }
-                        return true;
-                    }
                 }
+
+                // All checks passed
+                return true;
             }
 
+            /// <summary>
+            /// Generate a hash code for this STRUCT.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 int partial_hash = 1;
@@ -225,6 +267,10 @@ namespace KotOR_IO
                 return new { Type, Struct_Type, partial_hash, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write STRUCT information to string.
+            /// </summary>
+            /// <returns>[STRUCT] "Label", Struct_Type = _, # of Fields = _</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, Struct_Type = {Struct_Type}, # of Fields = {Fields?.Count ?? 0}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/E_Struct.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/E_Struct.cs
@@ -23,6 +23,11 @@ namespace KotOR_IO
             public List<FIELD> Fields { get; set; } = new List<FIELD>();
 
             /// <summary>
+            /// Index of this STRUCT in the GFF struct array. Used during GFF write.
+            /// </summary>
+            internal int Index { get; private set; } = -1;
+
+            /// <summary>
             /// Default constructor.
             /// </summary>
             public STRUCT() : base(GffFieldType.Struct) { }
@@ -206,7 +211,9 @@ namespace KotOR_IO
                 ref int Struct_Indexer,
                 ref int List_Indices_Counter)
             {
-                Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Struct_Indexer, this.GetHashCode());
+                Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Struct_Indexer, this.GetHashCode());    // Why is GetHashCode() used?
+                Index = Struct_Indexer;
+
                 Struct_Indexer++;
                 Field_Array.Add(T);
 
@@ -256,16 +263,16 @@ namespace KotOR_IO
             /// Generate a hash code for this STRUCT.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                int partial_hash = 1;
-                FIELD[] fieldArray = Fields.ToArray();
-                foreach (FIELD F in fieldArray)
-                {
-                    partial_hash *= F.GetHashCode();
-                }
-                return new { Type, Struct_Type, partial_hash, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    int partial_hash = 1;
+            //    FIELD[] fieldArray = Fields.ToArray();
+            //    foreach (FIELD F in fieldArray)
+            //    {
+            //        partial_hash *= F.GetHashCode();
+            //    }
+            //    return new { Type, Struct_Type, partial_hash, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write STRUCT information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/F_List.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/F_List.cs
@@ -137,17 +137,17 @@ namespace KotOR_IO
             /// Generate a hash code for this LIST.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                int partial_hash = 1;
-                STRUCT[] StructArray = Structs.ToArray();
-                foreach (STRUCT S in StructArray)
-                {
-                    partial_hash *= S.GetHashCode();
-                }
+            //public override int GetHashCode()
+            //{
+            //    int partial_hash = 1;
+            //    STRUCT[] StructArray = Structs.ToArray();
+            //    foreach (STRUCT S in StructArray)
+            //    {
+            //        partial_hash *= S.GetHashCode();
+            //    }
 
-                return new { Type, partial_hash, Label }.GetHashCode();
-            }
+            //    return new { Type, partial_hash, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write LIST information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/F_List.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/F_List.cs
@@ -7,17 +7,38 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// A LIST is a collection of STRUCT objects.
+        /// </summary>
         public class LIST : FIELD
         {
-            public List<STRUCT> Structs = new List<STRUCT>();
+            /// <summary>
+            /// Structs contained in this LIST.
+            /// </summary>
+            public List<STRUCT> Structs { get; set; } = new List<STRUCT>();
 
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public LIST() : base(GffFieldType.List) { }
+
+            /// <summary>
+            /// Construct using a custom list of structs.
+            /// </summary>
+            /// <param name="label"></param>
+            /// <param name="structs"></param>
             public LIST(string label, List<STRUCT> structs)
                 : base(GffFieldType.List, label)
             {
                 Label = label;
                 Structs = structs;
             }
+
+            /// <summary>
+            /// Construct by reading from a binary reader.
+            /// </summary>
+            /// <param name="br"></param>
+            /// <param name="offset"></param>
             internal LIST(BinaryReader br, int offset)
                 : base(GffFieldType.List)
             {
@@ -53,8 +74,20 @@ namespace KotOR_IO
                 }
             }
 
-            //Other
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, List_Indices_Counter, this.GetHashCode());
                 Field_Array.Add(T);
@@ -73,37 +106,37 @@ namespace KotOR_IO
 
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two LIST objects.
+            /// </summary>
+            /// <returns>True if the lists have the same Struct_Type, Label, and Fields.</returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label
+                if (!base.Equals(right))
                     return false;
-                }
-                else if (Structs.Count() != (obj as LIST).Structs.Count())
-                {
+
+                var other = right as LIST;
+                
+                // Check number of Structs
+                if (Structs.Count() != other.Structs.Count())
                     return false;
-                }
-                else if (Label != (obj as LIST).Label)
+
+                // Check each STRUCT
+                for (int i = 0; i < Structs.Count(); i++)
                 {
-                    return false;
+                    if (!Structs[i].Equals(other.Structs[i]))
+                        return false;
                 }
-                else
-                {
-                    for (int i = 0; i < Structs.Count(); i++)
-                    {
-                        if (Structs[i].Equals((obj as LIST).Structs[i]))
-                        {
-                            continue;
-                        }
-                        else
-                        {
-                            return false;
-                        }
-                    }
-                    return true;
-                }
+
+                // All checks passed
+                return true;
             }
 
+            /// <summary>
+            /// Generate a hash code for this LIST.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 int partial_hash = 1;
@@ -116,6 +149,10 @@ namespace KotOR_IO
                 return new { Type, partial_hash, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write LIST information to string.
+            /// </summary>
+            /// <returns>[LIST] "Label", # of Structs = _</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, # of Structs = {Structs?.Count ?? 0}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/G_Orientation.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/G_Orientation.cs
@@ -130,10 +130,10 @@ namespace KotOR_IO
             /// Generate a hash code for this Orientation.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, Value1, Value2, Value3, Value4, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, Value1, Value2, Value3, Value4, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write Orientation information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/G_Orientation.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/G_Orientation.cs
@@ -7,14 +7,39 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// An Orientation is a 
+        /// </summary>
         public class Orientation : FIELD
         {
-            public float Value1;
-            public float Value2;
-            public float Value3;
-            public float Value4;
+            /// <summary>
+            /// Value 1
+            /// </summary>
+            public float Value1 { get; set; }
 
+            /// <summary>
+            /// Value 2
+            /// </summary>
+            public float Value2 { get; set; }
+
+            /// <summary>
+            /// Value 3
+            /// </summary>
+            public float Value3 { get; set; }
+
+            /// <summary>
+            /// Value 4
+            /// </summary>
+            public float Value4 { get; set; }
+
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public Orientation() : base(GffFieldType.Orientation) { }
+
+            /// <summary>
+            /// Construct with label and values.
+            /// </summary>
             public Orientation(string label, int value1, int value2, int value3, int value4)
                 : base(GffFieldType.Orientation, label)
             {
@@ -23,35 +48,51 @@ namespace KotOR_IO
                 Value3 = value3;
                 Value4 = value4;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
             internal Orientation(BinaryReader br, int offset)
                 : base(GffFieldType.Orientation)
             {
-                //Header Info
+                // Header Info
                 br.BaseStream.Seek(24, 0);
                 int LabelOffset = br.ReadInt32();
                 int LabelCount = br.ReadInt32();
                 int FieldDataOffset = br.ReadInt32();
 
-                //Basic Field Data
+                // Basic Field Data
                 br.BaseStream.Seek(offset, 0);
                 Type = (GffFieldType)br.ReadInt32();
                 int LabelIndex = br.ReadInt32();
                 int DataOrDataOffset = br.ReadInt32();
 
-                //Label Logic
+                // Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
 
-                //Comlex Value Logic
+                // Complex Value Logic
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 Value1 = br.ReadSingle();
                 Value2 = br.ReadSingle();
                 Value3 = br.ReadSingle();
                 Value4 = br.ReadSingle();
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(Value1));
@@ -66,24 +107,38 @@ namespace KotOR_IO
                 }
             }
 
-
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two Orientation objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label.
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return Value1 == (obj as Orientation).Value1 && Value2 == (obj as Orientation).Value2 && Value3 == (obj as Orientation).Value3 && Value4 == (obj as Orientation).Value4 && Label == (obj as Orientation).Label;
-                }
+
+                // Check values.
+                var other = right as Orientation;
+                return Value1 == other.Value1 &&
+                       Value2 == other.Value2 &&
+                       Value3 == other.Value3 &&
+                       Value4 == other.Value4;
             }
 
+            /// <summary>
+            /// Generate a hash code for this Orientation.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, Value1, Value2, Value3, Value4, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write Orientation information to string.
+            /// </summary>
+            /// <returns>[Orientation] "Label", (v1, v2, v3, v4)</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, ({Value1}, {Value2}, {Value3}, {Value4})";

--- a/KotOR_IO/File Formats/GFF FieldTypes/H_Vector.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/H_Vector.cs
@@ -119,10 +119,10 @@ namespace KotOR_IO
             /// Generate a hash code for this Vector.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, X, Y, Z, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, X, Y, Z, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write Vector information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/H_Vector.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/H_Vector.cs
@@ -7,13 +7,34 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// An Vector is a set of 3 float values representing a direction in 3D space.
+        /// </summary>
         public class Vector : FIELD
         {
-            public float X;
-            public float Y;
-            public float Z;
+            /// <summary>
+            /// X value.
+            /// </summary>
+            public float X { get; set; }
 
+            /// <summary>
+            /// Y value.
+            /// </summary>
+            public float Y { get; set; }
+
+            /// <summary>
+            /// Z value.
+            /// </summary>
+            public float Z { get; set; }
+
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public Vector() : base(GffFieldType.Vector) { }
+
+            /// <summary>
+            /// Construct with label and values.
+            /// </summary>
             public Vector(string label, int x, int y, int z)
                 : base(GffFieldType.Vector, label)
             {
@@ -21,34 +42,50 @@ namespace KotOR_IO
                 Y = y;
                 Z = z;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
             internal Vector(BinaryReader br, int offset)
                 : base(GffFieldType.Vector)
             {
-                //Header Info
+                // Header Info
                 br.BaseStream.Seek(24, 0);
                 int LabelOffset = br.ReadInt32();
                 int LabelCount = br.ReadInt32();
                 int FieldDataOffset = br.ReadInt32();
 
-                //Basic Field Data
+                // Basic Field Data
                 br.BaseStream.Seek(offset, 0);
                 Type = (GffFieldType)br.ReadInt32();
                 int LabelIndex = br.ReadInt32();
                 int DataOrDataOffset = br.ReadInt32();
 
-                //Label Logic
+                // Label Logic
                 br.BaseStream.Seek(LabelOffset + LabelIndex * 16, 0);
                 Label = new string(br.ReadChars(16)).TrimEnd('\0');
 
-                //Comlex Value Logic
+                // Complex Value Logic
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 X = br.ReadSingle();
                 Y = br.ReadSingle();
                 Z = br.ReadSingle();
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(X));
@@ -62,23 +99,35 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two Vector objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label.
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return X == (obj as Vector).X && Y == (obj as Vector).Y && Z == (obj as Vector).Z && Label == (obj as Vector).Label;
-                }
+
+                // Check values.
+                var other = right as Vector;
+                return X == other.X && Y == other.Y && Z == other.Z;
             }
 
+            /// <summary>
+            /// Generate a hash code for this Vector.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, X, Y, Z, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write Vector information to string.
+            /// </summary>
+            /// <returns>[Vector] "Label", (X, Y, Z)</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, ({X}, {Y}, {Z})";

--- a/KotOR_IO/File Formats/GFF FieldTypes/I_StrRef.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/I_StrRef.cs
@@ -111,10 +111,10 @@ namespace KotOR_IO
             /// Generate a hash code for this StrRef.
             /// </summary>
             /// <returns></returns>
-            public override int GetHashCode()
-            {
-                return new { Type, LeadingValue, Reference, Label }.GetHashCode();
-            }
+            //public override int GetHashCode()
+            //{
+            //    return new { Type, LeadingValue, Reference, Label }.GetHashCode();
+            //}
 
             /// <summary>
             /// Write StrRef information to string.

--- a/KotOR_IO/File Formats/GFF FieldTypes/I_StrRef.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/I_StrRef.cs
@@ -7,18 +7,39 @@ namespace KotOR_IO
 {
     public partial class GFF
     {
+        /// <summary>
+        /// An StrRef is a 
+        /// </summary>
         public class StrRef : FIELD
         {
-            public int LeadingValue;
-            public int Reference;
+            /// <summary>
+            /// 
+            /// </summary>
+            public int LeadingValue { get; set; }
 
+            /// <summary>
+            /// 
+            /// </summary>
+            public int Reference { get; set; }
+
+            /// <summary>
+            /// Default constructor.
+            /// </summary>
             public StrRef() : base(GffFieldType.StrRef) { }
+
+            /// <summary>
+            /// Construct with label and values.
+            /// </summary>
             public StrRef(string label, int leading_value, int reference)
                 : base(GffFieldType.StrRef, label)
             {
                 LeadingValue = leading_value;
                 Reference = reference;
             }
+
+            /// <summary>
+            /// Construct by reading a binary reader.
+            /// </summary>
             internal StrRef(BinaryReader br, int offset)
                 : base(GffFieldType.StrRef)
             {
@@ -42,10 +63,22 @@ namespace KotOR_IO
                 br.BaseStream.Seek(FieldDataOffset + DataOrDataOffset, 0);
                 LeadingValue = br.ReadInt32();
                 Reference = br.ReadInt32();
-
             }
 
-            internal override void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter)
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            internal override void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter)
             {
                 Tuple<FIELD, int, int> T = new Tuple<FIELD, int, int>(this, Raw_Field_Data_Block.Count, this.GetHashCode());
                 Raw_Field_Data_Block.AddRange(BitConverter.GetBytes(LeadingValue));
@@ -58,23 +91,35 @@ namespace KotOR_IO
                 }
             }
 
-            public override bool Equals(object obj)
+            /// <summary>
+            /// Test equality between two StrRef objects.
+            /// </summary>
+            /// <param name="right"></param>
+            /// <returns></returns>
+            public override bool Equals(object right)
             {
-                if ((obj == null) || !GetType().Equals(obj.GetType()))
-                {
+                // Check null, self, type, Gff Type, and Label.
+                if (!base.Equals(right))
                     return false;
-                }
-                else
-                {
-                    return LeadingValue == (obj as StrRef).LeadingValue && Reference == (obj as StrRef).Reference && Label == (obj as StrRef).Label;
-                }
+
+                // Check values.
+                var other = right as StrRef;
+                return LeadingValue == other.LeadingValue && Reference == other.Reference;
             }
 
+            /// <summary>
+            /// Generate a hash code for this StrRef.
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return new { Type, LeadingValue, Reference, Label }.GetHashCode();
             }
 
+            /// <summary>
+            /// Write StrRef information to string.
+            /// </summary>
+            /// <returns>[StrRef] "Label", Leading Value = _, StrRef = _</returns>
             public override string ToString()
             {
                 return $"{base.ToString()}, Leading Value = {LeadingValue}, StrRef = {Reference}";

--- a/KotOR_IO/File Formats/GFF FieldTypes/_FIELD.cs
+++ b/KotOR_IO/File Formats/GFF FieldTypes/_FIELD.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace KotOR_IO
+{
+    public partial class GFF
+    {
+        /// <summary>
+        /// Abstract class that all the fields that make the GFF are based off of.
+        /// </summary>
+        public abstract class FIELD
+        {
+            /// <summary>
+            /// Maximum length of the string Label.
+            /// </summary>
+            public const int MAX_LABEL_LENGTH = 16;
+
+            /// <summary>
+            /// Type of this GFF field.
+            /// </summary>
+            public GffFieldType Type { get; set; }
+
+            /// <summary>
+            /// String label.
+            /// </summary>
+            public string Label { get; set; }
+
+            /// <summary>
+            /// Collect fields recursively.
+            /// </summary>
+            /// <param name="Field_Array"></param>
+            /// <param name="Raw_Field_Data_Block"></param>
+            /// <param name="Label_Array"></param>
+            /// <param name="Struct_Indexer"></param>
+            /// <param name="List_Indices_Counter"></param>
+            abstract internal void collect_fields(
+                ref List<Tuple<FIELD, int, int>> Field_Array,
+                ref List<byte> Raw_Field_Data_Block,
+                ref List<string> Label_Array,
+                ref int Struct_Indexer,
+                ref int List_Indices_Counter);
+
+            internal FIELD(GffFieldType type, string label = "")
+            {
+                if (label.Length > MAX_LABEL_LENGTH)
+                    throw new Exception($"Label \"{label}\" is longer than {MAX_LABEL_LENGTH} characters, and is invalid.");
+
+                Type = type;
+                Label = label;
+            }
+
+            /// <summary>
+            /// Write FIELD information to string.
+            /// </summary>
+            /// <returns>[Type] "Label", {specific field info}</returns>
+            public override string ToString()
+            {
+                return $"[{Type}] \"{Label}\"";
+            }
+
+            /// <summary>
+            /// Test equality between two FIELD objects.
+            /// </summary>
+            /// <returns>True if the FIELDs contain the same data.</returns>
+            public override bool Equals(object right)
+            {
+                // Check null
+                if (right is null)
+                    return false;
+
+                // Check self
+                if (object.ReferenceEquals(this, right))
+                    return true;
+
+                // Check type
+                if (this.GetType() != right.GetType())
+                    return false;
+
+                // Check GFF Type
+                var other = right as FIELD;
+                if (Type != other.Type)
+                    return false;
+
+                // Check Label
+                if (Label != other.Label)
+                    return false;
+
+                // All checks passed
+                return true;
+            }
+
+            /// <summary>
+            /// Get default reference hash code as base.
+            /// </summary>
+            public override int GetHashCode()
+            {
+                return base.GetHashCode();
+            }
+        }
+    }
+}

--- a/KotOR_IO/File Formats/GFF.cs
+++ b/KotOR_IO/File Formats/GFF.cs
@@ -6,61 +6,55 @@ using System.IO;
 namespace KotOR_IO
 {
     /// <summary>
-    /// General File Format - The Format used for about 50% of the files in this game. Including, but not limited to: Creatures, Doors, Placeables, Items, Dialogue, GUIs, and Module Layouts
+    /// General File Format - The Format used for about 50% of the files in this game.
+    /// Including, but not limited to: Creatures, Doors, Placeables, Items, Dialogue,
+    /// GUIs, and Module Layouts.
     /// </summary>
     public partial class GFF : KFile
     {
-        //Type Definitions
+        /// <summary> Bytes in an int. </summary>
+        protected const int SIZEOF_INT = 4;
+
         /// <summary>
-        /// Abstract class that all the fields that make the GFF are based off of.
+        /// Top level of this container.
         /// </summary>
-        public abstract class FIELD //A GFF is just a collection of nested fields
-        {
-            public const int MAX_LABEL_LENGTH = 16;
+        public STRUCT Top_Level { get; set; }
 
-            public GffFieldType Type;
-            public string Label;
-
-            abstract internal void collect_fields(ref List<Tuple<FIELD, int, int>> Field_Array, ref List<byte> Raw_Field_Data_Block, ref List<string> Label_Array, ref int Struct_Indexer, ref int List_Indices_Counter);
-
-            internal FIELD(GffFieldType type, string label = "")
-            {
-                if (label.Length > MAX_LABEL_LENGTH)
-                    throw new Exception($"Label \"{label}\" is longer than {MAX_LABEL_LENGTH} characters, and is invalid.");
-
-                Type = type;
-                Label = label;
-            }
-
-            public override string ToString()
-            {
-                return $"[{Type}] \"{Label}\"";
-            }
-        }
-
-
-        //Declarations
-        public string FileType;
-        public string Version;
-        public STRUCT Top_Level;
-
-        //Construction
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
         public GFF()
         {
             Top_Level = new STRUCT();
         }
+
+        /// <summary>
+        /// Construct GFF using a custom top level STRUCT.
+        /// </summary>
         public GFF(string FileType, string Version, STRUCT Top_Level)
         {
             this.FileType = FileType;
             this.Version = Version;
             this.Top_Level = Top_Level;
         }
+
+        /// <summary>
+        /// Construct GFF by reading a raw byte[] data stream.
+        /// </summary>
         public GFF(byte[] rawData)
             : this(new MemoryStream(rawData))
         { }
+
+        /// <summary>
+        /// Construct GFF by reading file at path.
+        /// </summary>
         public GFF(string path)
             : this(File.OpenRead(path))
         { }
+
+        /// <summary>
+        /// Construct GFF by reading a generic data stream.
+        /// </summary>
         public GFF(Stream s)
         {
             using (BinaryReader br = new BinaryReader(s))
@@ -68,20 +62,24 @@ namespace KotOR_IO
                 FileType = new string(br.ReadChars(4));
                 Version = new string(br.ReadChars(4));
 
+                // Begin reading top level STRUCT data.
                 Top_Level = new STRUCT(br, 0);
             }
 
         }
 
-        //Write Methods
+        /// <summary>
+        /// Write GFF data to a generic data stream.
+        /// </summary>
         internal override void Write(Stream s)
         {
-            //List out all the fields in the file, followed by their DataOrDataOffset, and then their HasCode.
+            // List out all the fields in the file, followed by their DataOrDataOffset, and then their HasCode.
             List<Tuple<FIELD, int, int>> Field_Array = new List<Tuple<FIELD, int, int>>();
-            //Contains all teh unique labels used by the file
+
+            // Contains all the unique labels used by the file.
             List<string> Label_Array = new List<string>();
 
-            //Raw Arrays that will store the bytes to be written to the File
+            // Raw Arrays that will store the bytes to be written to the File.
             List<byte> Raw_Struct_Array = new List<byte>();
             List<byte> Raw_Field_Array = new List<byte>();
             List<byte> Raw_Label_Array = new List<byte>();
@@ -89,14 +87,14 @@ namespace KotOR_IO
             List<byte> Raw_Field_Indices_Array = new List<byte>();
             List<byte> Raw_List_Indices_Array = new List<byte>();
 
-            //Indexers/Counters
+            // Indexers/Counters
             int Struct_Indexer = 0;
             int List_Indices_Counter = 0;
 
-            //Recursive field collection call
+            // Recursive field collection call
             Top_Level.collect_fields(ref Field_Array, ref Raw_Field_Data_Block, ref Label_Array, ref Struct_Indexer, ref List_Indices_Counter);
 
-            //Preparing raw struct data
+            // Preparing raw struct data
             for (int i = 0; i < Struct_Indexer; i++)
             {
                 STRUCT S = Field_Array.Where(x => x.Item1.Type == GffFieldType.Struct && x.Item2 == i).Select(x => x.Item1 as STRUCT).FirstOrDefault();
@@ -122,19 +120,20 @@ namespace KotOR_IO
                         Raw_Field_Indices_Array.AddRange(BitConverter.GetBytes(f_index));
                     }
 
-                    //Depricated code for when I was using a counter and handling Field Indices separately
+                    // Depricated code for when I was using a counter and handling Field Indices separately
                     //Raw_Struct_Array.AddRange(BitConverter.GetBytes(Field_Indices_Counter));
                     //Field_Indices_Counter += 4 * S.Fields.Count;
                 }
                 else
                 {
-                    //Empty Struct case (this is rare)
+                    // Empty Struct case (this is rare)
                     Raw_Struct_Array.AddRange(BitConverter.GetBytes(-1));
                 }
+
                 Raw_Struct_Array.AddRange(BitConverter.GetBytes(f_count));
             }
 
-            //Preparing raw Field data
+            // Preparing raw Field data
             foreach (Tuple<FIELD, int, int> T in Field_Array)
             {
                 Raw_Field_Array.AddRange(BitConverter.GetBytes((int)T.Item1.Type)); //Field Type
@@ -143,17 +142,17 @@ namespace KotOR_IO
                 Raw_Field_Array.AddRange(BitConverter.GetBytes(T.Item2)); //DataOrDataOffset
             }
 
-            //Preparing raw Label data
+            // Preparing raw Label data
             foreach (string l in Label_Array)
             {
                 Raw_Label_Array.AddRange(l.PadRight(16, '\0').ToCharArray().Select(x => (byte)x));
             }
 
-            //Field Data block should've been prapared during collect_fields call
-            //Field Indice block should've been prapared while generating struct data
+            // Field Data block should've been prapared during collect_fields call
+            // Field Indice block should've been prapared while generating struct data
 
-            //Preparing raw List indices data
-            for (int i = 0; i < List_Indices_Counter;)
+            // Preparing raw List indices data
+            for (int i = 0; i < List_Indices_Counter; i = Raw_List_Indices_Array.Count)
             {
                 LIST L = Field_Array.Where(x => x.Item1.Type == GffFieldType.List && x.Item2 == Raw_List_Indices_Array.Count).Select(x => x.Item1 as LIST).FirstOrDefault();
                 Raw_List_Indices_Array.AddRange(BitConverter.GetBytes(L.Structs.Count));
@@ -163,13 +162,11 @@ namespace KotOR_IO
                     int s_index = Field_Array.Where(x => x.Item3 == s_hash).FirstOrDefault().Item2;
                     Raw_List_Indices_Array.AddRange(BitConverter.GetBytes(s_index));
                 }
-
-                i = Raw_List_Indices_Array.Count;
-
             }
 
-            //Header Calculations
-            int StructOffset = 56;
+            // Header Calculations
+            // 56 bytes in the header: 12 ints (4 bytes each) + type and version (4 bytes each)
+            int StructOffset = 12 * SIZEOF_INT + SIZEOF_FILEINFO;
             int StructCount = Raw_Struct_Array.Count / 12;
             int FieldOffset = StructOffset + StructCount * 12;
             int FieldCount = Field_Array.Count;
@@ -182,10 +179,10 @@ namespace KotOR_IO
             int ListIndicesOffset = FieldIndicesOffset + FieldIndicesCount;
             int ListIndicesCount = Raw_List_Indices_Array.Count;
 
-            //Writing
+            // Writing
             using (BinaryWriter bw = new BinaryWriter(s))
             {
-                //header
+                // Write header information
                 bw.Write(FileType.ToCharArray());
                 bw.Write(Version.ToCharArray());
                 bw.Write(StructOffset);
@@ -201,31 +198,28 @@ namespace KotOR_IO
                 bw.Write(ListIndicesOffset);
                 bw.Write(ListIndicesCount);
 
-                //structs
-                bw.Write(Raw_Struct_Array.ToArray());
-
-                //fields
-                bw.Write(Raw_Field_Array.ToArray());
-
-                //labels
-                bw.Write(Raw_Label_Array.ToArray());
-
-                //field data
-                bw.Write(Raw_Field_Data_Block.ToArray());
-
-                //fields indices
-                bw.Write(Raw_Field_Indices_Array.ToArray());
-
-                //list indices
-                bw.Write(Raw_List_Indices_Array.ToArray());
+                // Write data
+                bw.Write(Raw_Struct_Array.ToArray());           // structs
+                bw.Write(Raw_Field_Array.ToArray());            // fields
+                bw.Write(Raw_Label_Array.ToArray());            // labels
+                bw.Write(Raw_Field_Data_Block.ToArray());       // field data
+                bw.Write(Raw_Field_Indices_Array.ToArray());    // fields indices
+                bw.Write(Raw_List_Indices_Array.ToArray());     // list indices
             }
         }
 
+        /// <summary>
+        /// Write GFF data to a new file at the given path.
+        /// </summary>
         public override void WriteToFile(string path)
         {
             Write(File.OpenWrite(path));
         }
 
+        /// <summary>
+        /// Write GFF data to a raw byte[].
+        /// </summary>
+        /// <returns>byte[] of GFF data</returns>
         public override byte[] ToRawData()
         {
             using (MemoryStream ms = new MemoryStream())
@@ -234,6 +228,5 @@ namespace KotOR_IO
                 return ms.ToArray(); // Stream is closed, but the array is still available.
             }
         }
-
     }
 }

--- a/KotOR_IO/File Formats/GFF_old.cs
+++ b/KotOR_IO/File Formats/GFF_old.cs
@@ -313,7 +313,7 @@ namespace KotOR_IO
         public List<List_Index> List_Indices = new List<List_Index>();
 
         /// <summary>
-        /// Gets field data given a field label. If more than one fields have this label, type will be <see cref="List{object}"/>, otherwise type will be <see cref="object"/>
+        /// Gets field data given a field label. If more than one fields have this label, type will be <see cref="List{Object}"/>, otherwise type will be <see cref="object"/>
         /// </summary>
         /// <param name="Field_Label"></param>
         /// <returns></returns>

--- a/KotOR_IO/File Formats/KFile.cs
+++ b/KotOR_IO/File Formats/KFile.cs
@@ -22,6 +22,9 @@ namespace KotOR_IO
     /// </summary>
     public abstract class KFile
     {
+        /// <summary> Number of bytes in the header info (FileType and Version). </summary>
+        protected const int SIZEOF_FILEINFO = 8;
+
         /// <summary> ASCII value of NUL character. </summary>
         protected const byte ASCII_NULL = 0;
 

--- a/KotOR_IO/File Formats/LIP.cs
+++ b/KotOR_IO/File Formats/LIP.cs
@@ -32,6 +32,10 @@ namespace KotOR_IO
             : this(File.OpenRead(path))
         { }
 
+        /// <summary>
+        /// Read a generic data Stream.
+        /// </summary>
+        /// <param name="s"></param>
         protected LIP(Stream s)
         {
             using (BinaryReader br = new BinaryReader(s))

--- a/KotOR_IO/KotOR_IO.csproj
+++ b/KotOR_IO/KotOR_IO.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="File Formats\BIF.cs" />
     <Compile Include="File Formats\ERF.cs" />
+    <Compile Include="File Formats\GFF FieldTypes\_FIELD.cs" />
     <Compile Include="File Formats\GFF FieldTypes\I_StrRef.cs" />
     <Compile Include="File Formats\GFF FieldTypes\H_Vector.cs" />
     <Compile Include="File Formats\GFF FieldTypes\G_Orientation.cs" />

--- a/KotOR_IO/Properties/AssemblyInfo.cs
+++ b/KotOR_IO/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/test8/Program.cs
+++ b/test8/Program.cs
@@ -65,7 +65,7 @@ namespace test8
             BIF templates = new BIF(fileToRead);
             GFF utc = new GFF(templates.VariableResourceTable.First(vre => vre.ResourceType == ResourceType.UTC).EntryData);
             
-
+            // Read GFF file.
             var filename = @"C:\Dev\KIO Test\test1.git";
             var fileinfo = new FileInfo(filename);
             Console.WriteLine($" file size: {fileinfo.Length:N0} bytes");
@@ -73,30 +73,12 @@ namespace test8
             GFF test = new GFF(filename);
             Console.WriteLine($" read size: {test.ToRawData().Length:N0} bytes");
 
+            // Write GFF object to file.
             var filename2 = @"C:\Dev\KIO Test\test2.git";
             test.WriteToFile(filename2);
 
             var fileinfo2 = new FileInfo(filename2);
             Console.WriteLine($"write size: {fileinfo2.Length:N0} bytes");
-
-            var test2 = new GFF(filename2); // Exception: Stack overflow
-            var raw2 = test2.ToRawData();
-
-            var filename3 = @"C:\Dev\KIO Test\test3.git";
-            test2.WriteToFile(filename3);
-
-
-            //DirectoryInfo di = new DirectoryInfo("C:\\Program Files (x86)\\Steam\\steamapps\\common\\swkotor\\modules - Copy");
-            //foreach (FileInfo fi in di.EnumerateFiles())
-            //{
-            //    RIM r = new RIM(Path.Combine(fi.DirectoryName, fi.Name));
-            //    r.WriteToFile(Path.Combine("C:\\Program Files (x86)\\Steam\\steamapps\\common\\swkotor\\modules\\", fi.Name));
-            //}
-
-
-            //RIM r = new RIM("D:\\ExampleFiles\\danm13.rim");
-            //r.WriteToFile("D:\\ExampleFiles\\danm13T.rim");
-            //RIM r2 = new RIM("D:\\ExampleFiles\\danm13T.rim");
 
             Console.ReadLine();
         }

--- a/test8/Program.cs
+++ b/test8/Program.cs
@@ -61,18 +61,39 @@ namespace test8
 
         static void Main(string[] args)
         {
-            DirectoryInfo di = new DirectoryInfo("C:\\Program Files (x86)\\Steam\\steamapps\\common\\swkotor\\modules - Copy");
-            foreach (FileInfo fi in di.EnumerateFiles())
-            {
-                RIM r = new RIM(Path.Combine(fi.DirectoryName, fi.Name));
-                r.WriteToFile(Path.Combine("C:\\Program Files (x86)\\Steam\\steamapps\\common\\swkotor\\modules\\", fi.Name));
-            }
+            var filename = @"C:\Dev\KIO Test\test1.git";
+            var fileinfo = new FileInfo(filename);
+            Console.WriteLine($" file size: {fileinfo.Length:N0} bytes");
+
+            GFF test = new GFF(filename);
+            Console.WriteLine($" read size: {test.ToRawData().Length:N0} bytes");
+
+            var filename2 = @"C:\Dev\KIO Test\test2.git";
+            test.WriteToFile(filename2);
+
+            var fileinfo2 = new FileInfo(filename2);
+            Console.WriteLine($"write size: {fileinfo2.Length:N0} bytes");
+
+            var test2 = new GFF(filename2); // Exception: Stack overflow
+            var raw2 = test2.ToRawData();
+
+            var filename3 = @"C:\Dev\KIO Test\test3.git";
+            test2.WriteToFile(filename3);
+
+
+            //DirectoryInfo di = new DirectoryInfo("C:\\Program Files (x86)\\Steam\\steamapps\\common\\swkotor\\modules - Copy");
+            //foreach (FileInfo fi in di.EnumerateFiles())
+            //{
+            //    RIM r = new RIM(Path.Combine(fi.DirectoryName, fi.Name));
+            //    r.WriteToFile(Path.Combine("C:\\Program Files (x86)\\Steam\\steamapps\\common\\swkotor\\modules\\", fi.Name));
+            //}
 
 
             //RIM r = new RIM("D:\\ExampleFiles\\danm13.rim");
             //r.WriteToFile("D:\\ExampleFiles\\danm13T.rim");
             //RIM r2 = new RIM("D:\\ExampleFiles\\danm13T.rim");
-            Console.Write("");
+
+            Console.ReadLine();
         }
     }
 }

--- a/test8/Program.cs
+++ b/test8/Program.cs
@@ -61,6 +61,11 @@ namespace test8
 
         static void Main(string[] args)
         {
+            var fileToRead = @"C:\Program Files (x86)\Steam\steamapps\common\swkotor\data\templates.bif";
+            BIF templates = new BIF(fileToRead);
+            GFF utc = new GFF(templates.VariableResourceTable.First(vre => vre.ResourceType == ResourceType.UTC).EntryData);
+            
+
             var filename = @"C:\Dev\KIO Test\test1.git";
             var fileinfo = new FileInfo(filename);
             Console.WriteLine($" file size: {fileinfo.Length:N0} bytes");


### PR DESCRIPTION
The issue was structs that are contained within lists should not be included in the fields array like other structs. Additionally, this means that an empty string label shouldn't appear in the labels array either. At least, that is my current assumption. If there are any files that can be shown to have an empty label that doesn't belong to a struct inside a list, a new fix will need to be implemented.