### PR TITLE
New GFF derivative file types

### DIFF
--- a/KotOR_IO/File Formats/GFF FileTypes/GIT.cs
+++ b/KotOR_IO/File Formats/GFF FileTypes/GIT.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KotOR_IO.GffFile
+{
+    public class GIT : GffDerivative
+    {
+        #region Consts
+        private const string AREA_PROPERTIES = "AreaProperties";
+        private const string CAMERA_LIST = "CameraList";
+        private const string CREATURE_LIST = "Creature List";
+        private const string DOOR_LIST = "Door List";
+        private const string ENCOUNTER_LIST = "Encounter List";
+        private const string LIST = "List";
+        private const string PLACEABLE_LIST = "Placeable List";
+        private const string SOUND_LIST = "SoundList";
+        private const string STORE_LIST = "StoreList";
+        private const string TRIGGER_LIST = "TriggerList";
+        private const string USE_TEMPLATES = "UseTemplates";
+        private const string WAYPOINT_LIST = "WaypointList";
+        #endregion
+
+        #region Properties
+        public GFF.STRUCT AreaProperties { get; set; }
+        public GFF.LIST Cameras { get; set; }
+        public GFF.LIST Creatures { get; set; }
+        public GFF.LIST Doors { get; set; }
+        public GFF.LIST Encounters { get; set; }
+        public GFF.LIST List { get; set; }
+        public IEnumerable<Placeable> Placeables { get; set; }
+        public GFF.LIST Sounds { get; set; }
+        public GFF.LIST Stores { get; set; }
+        public GFF.LIST Triggers { get; set; }
+        public GFF.BYTE UseTemplates { get; set; }
+        public GFF.LIST Waypoints { get; set; }
+        #endregion
+
+        #region Constructors
+
+        private GIT(GFF gff)
+            : base(gff)
+        {
+            AreaProperties = GFF.Top_Level.Fields.FirstOrDefault(f => f.Label == AREA_PROPERTIES) as GFF.STRUCT;
+            Cameras = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == CAMERA_LIST) as GFF.LIST;
+            Creatures = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == CREATURE_LIST) as GFF.LIST;
+            Doors = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == DOOR_LIST) as GFF.LIST;
+            Encounters = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == ENCOUNTER_LIST) as GFF.LIST;
+            List = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == LIST) as GFF.LIST;
+
+            // Create list of Placeable objects.
+            if (gff.Top_Level.Fields.FirstOrDefault(f => f.Label == PLACEABLE_LIST) is GFF.LIST list && list.Structs.Any())
+                Placeables = list.Structs.Select(s => new Placeable(s));
+
+            Sounds = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == SOUND_LIST) as GFF.LIST;
+            Stores = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == STORE_LIST) as GFF.LIST;
+            Triggers = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == TRIGGER_LIST) as GFF.LIST;
+            UseTemplates = GFF.Top_Level.Fields.FirstOrDefault(f => f.Label == USE_TEMPLATES) as GFF.BYTE;
+            Waypoints = gff.Top_Level.Fields.FirstOrDefault(f => f.Label == WAYPOINT_LIST) as GFF.LIST;
+        }
+
+        /// <summary>
+        /// Creates a new GIT object that wraps a GFF object.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if argument gff is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if argument gff is not of type GIT.</exception>
+        /// <exception cref="InvalidDataException">Thrown if argument gff contains no fields.</exception>
+        public static GIT NewGIT(GFF gff)
+        {
+            if (gff == null)
+            {
+                throw new ArgumentNullException($"Argument {nameof(gff)} cannot be null.");
+            }
+
+            if (gff.FileType != ResourceType.GIT.ToDescription())
+            {
+                throw new ArgumentException($"Unable to create GIT from a GFF of type {gff.FileType.Trim()}.");
+            }
+
+            if (gff.Top_Level == null || (gff.Top_Level.Fields?.Count ?? 0) == 0)
+            {
+                throw new InvalidDataException($"Argument {nameof(gff)} must have fields.");
+            }
+
+            return new GIT(gff);
+        }
+
+        #endregion
+
+        #region Nested Classes
+
+        public struct Placeable
+        {
+            public readonly string TemplateResRef;
+            public readonly float Bearing;
+            public readonly float X;
+            public readonly float Y;
+            public readonly float Z;
+
+            public Placeable(GFF.STRUCT gffStruct)
+            {
+                Bearing = (gffStruct.Fields.FirstOrDefault(f => f.Label == nameof(Bearing)) as GFF.FLOAT).Value;
+                TemplateResRef = (gffStruct.Fields.FirstOrDefault(f => f.Label == nameof(TemplateResRef)) as GFF.ResRef).Reference;
+                X = (gffStruct.Fields.FirstOrDefault(f => f.Label == nameof(X)) as GFF.FLOAT).Value;
+                Y = (gffStruct.Fields.FirstOrDefault(f => f.Label == nameof(Y)) as GFF.FLOAT).Value;
+                Z = (gffStruct.Fields.FirstOrDefault(f => f.Label == nameof(Z)) as GFF.FLOAT).Value;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/KotOR_IO/File Formats/GFF FileTypes/GffDerivative.cs
+++ b/KotOR_IO/File Formats/GFF FileTypes/GffDerivative.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KotOR_IO.GffFile
+{
+    public abstract class GffDerivative : KFile
+    {
+        public GFF GFF { get; private set; }
+
+        protected GffDerivative(GFF gff)
+        {
+            GFF = gff;
+        }
+
+        internal override void Write(Stream s)
+        {
+            GFF.Write(s);
+        }
+    }
+}

--- a/KotOR_IO/File Formats/KEY.cs
+++ b/KotOR_IO/File Formats/KEY.cs
@@ -118,6 +118,12 @@ namespace KotOR_IO
         /// <summary> A list of all the <see cref="KeyEntry"/>s associted with the linked <see cref="BIF"/> files. </summary>
         public List<KeyEntry> KeyTable { get; set; } = new List<KeyEntry>();
 
+        /// <summary>Returns a string that represents the current object.</summary>
+        public override string ToString()
+        {
+            return $"Files: {FileTable.Count}, Keys: {KeyTable.Count}";
+        }
+
         /// <summary>
         /// Writes Bioware Key File data
         /// </summary>
@@ -180,6 +186,12 @@ namespace KotOR_IO
 
             ///<summary>The Filename of the <see cref="BIF"/> as a path from the <see cref="KEY"/>'s root directory</summary>
             public string Filename;
+
+            /// <summary>Returns a string that represents the current object.</summary>
+            public override string ToString()
+            {
+                return Filename;
+            }
         }
 
         // Key Table
@@ -203,6 +215,12 @@ namespace KotOR_IO
             public int IDx;
             ///<summary>The y component of <see cref="ResID"/> which is an index into the <see cref="BIF.VariableResourceTable"/></summary>
             public int IDy;
+
+            /// <summary>Returns a string that represents the current object.</summary>
+            public override string ToString()
+            {
+                return $"[{Type_Text.ToUpper()}] '{ResRef}'";
+            }
         }
     }
 }

--- a/KotOR_IO/File Formats/RIM.cs
+++ b/KotOR_IO/File Formats/RIM.cs
@@ -79,7 +79,8 @@ namespace KotOR_IO
                     File_Table.Add(URF.rf);
                 }
 
-                GitFile = GIT.NewGIT(new GFF(File_Table.FirstOrDefault(f => f.TypeID == (int)ResourceType.GIT).File_Data));
+                var gitFile = File_Table.FirstOrDefault(f => f.TypeID == (int)ResourceType.GIT);
+                if (gitFile != null) GitFile = GIT.NewGIT(new GFF(gitFile.File_Data));
             }
         }
 

--- a/KotOR_IO/File Formats/RIM.cs
+++ b/KotOR_IO/File Formats/RIM.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using KotOR_IO.GffFile;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -77,6 +78,8 @@ namespace KotOR_IO
 
                     File_Table.Add(URF.rf);
                 }
+
+                GitFile = GIT.NewGIT(new GFF(File_Table.FirstOrDefault(f => f.TypeID == (int)ResourceType.GIT).File_Data));
             }
         }
 
@@ -101,6 +104,11 @@ namespace KotOR_IO
         /// All of the <see cref="rFile"/>s contained within the <see cref="RIM"/> at their respective Index. This is the primary property of the <see cref="RIM"/>.
         /// </summary>
         public List<rFile> File_Table = new List<rFile>();
+
+        /// <summary>
+        /// GIT file of this RIM.
+        /// </summary>
+        public GIT GitFile { get; private set; }
 
         /// <summary>
         /// Appends a new KFile to the end of the <see cref="RIM"/>.

--- a/KotOR_IO/File Formats/TLK.cs
+++ b/KotOR_IO/File Formats/TLK.cs
@@ -152,6 +152,12 @@ namespace KotOR_IO
             }
         }
 
+        /// <summary>Returns a string that represents the current object.</summary>
+        public override string ToString()
+        {
+            return $"Strings: {String_Data_Table.Count}";
+        }
+
         // String Data Table
         /// <summary>
         /// An element on the <see cref="String_Data_Table"/>.
@@ -209,6 +215,12 @@ namespace KotOR_IO
 
             /// <summary> The text associated with the string. </summary>
             public string StringText;
+
+            /// <summary>Returns a string that represents the current object.</summary>
+            public override string ToString()
+            {
+                return StringText.Length > 80 ? $"{StringText.Substring(0, 78)}..." : StringText;
+            }
         }
     }
 }

--- a/KotOR_IO/KotOR_IO.csproj
+++ b/KotOR_IO/KotOR_IO.csproj
@@ -65,6 +65,8 @@
     <Compile Include="File Formats\GFF FieldTypes\2_WORD.cs" />
     <Compile Include="File Formats\GFF FieldTypes\1_CHAR.cs" />
     <Compile Include="File Formats\GFF FieldTypes\0_BYTE.cs" />
+    <Compile Include="File Formats\GFF FileTypes\GffDerivative.cs" />
+    <Compile Include="File Formats\GFF FileTypes\GIT.cs" />
     <Compile Include="File Formats\GFF.cs" />
     <Compile Include="File Formats\GFF_old.cs" />
     <Compile Include="File Formats\KEY.cs" />

--- a/KotOR_IO/Properties/AssemblyInfo.cs
+++ b/KotOR_IO/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.2.0")]
-[assembly: AssemblyFileVersion("1.4.2.0")]
+[assembly: AssemblyVersion("1.4.3.0")]
+[assembly: AssemblyFileVersion("1.4.3.0")]


### PR DESCRIPTION
This is the initial commit of the GIT file type. These new classes are used by the Walkmesh Visualizer. It could be improved further, but I think it's a fine start to retrieve information from this file type.